### PR TITLE
feat(match): update MatchPlayer to use UUID for IDs and enhance queries

### DIFF
--- a/src/main/java/com/chnu/seabattle/entity/MatchPlayer.java
+++ b/src/main/java/com/chnu/seabattle/entity/MatchPlayer.java
@@ -19,14 +19,14 @@ import java.util.UUID;
 public class MatchPlayer {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
 
     @ManyToOne
     @JoinColumn(name = "match_id", nullable = false)
     private Match match;
 
-    @JoinColumn(name = "user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
     private UUID userId;
 
     @Column(nullable = false)

--- a/src/main/java/com/chnu/seabattle/entity/MoveResult.java
+++ b/src/main/java/com/chnu/seabattle/entity/MoveResult.java
@@ -3,5 +3,6 @@ package com.chnu.seabattle.entity;
 public enum MoveResult {
     MISS,
     HIT,
-    SUNK
+    SUNK,
+    FINISHED
 }

--- a/src/main/java/com/chnu/seabattle/repository/MatchPlayerRepository.java
+++ b/src/main/java/com/chnu/seabattle/repository/MatchPlayerRepository.java
@@ -9,8 +9,12 @@ import java.util.UUID;
 
 @Repository
 public interface MatchPlayerRepository extends JpaRepository<MatchPlayer, Long> {
-    Optional<MatchPlayer> findByMatchIdAndUserId(
-            Long matchId, UUID userId
+    Optional<MatchPlayer> findByMatchIdAndId(
+            Long matchId, UUID MatchPlayerId
+    );
+
+    Optional<MatchPlayer> findByMatchIdAndReconnectToken(
+            Long matchId, String reconnectToken
     );
 
 }

--- a/src/main/java/com/chnu/seabattle/service/MatchService.java
+++ b/src/main/java/com/chnu/seabattle/service/MatchService.java
@@ -16,7 +16,7 @@ public interface MatchService {
 
     Match joinMatch(UUID playerId, String inviteToken);
 
-//    Match getMatchById(Long matchId);
+    Match getMatchById(Long matchId);
 
     Match getMatchByInviteToken(String inviteToken);
 }

--- a/src/main/java/com/chnu/seabattle/service/serviceImpl/MatchServiceImpl.java
+++ b/src/main/java/com/chnu/seabattle/service/serviceImpl/MatchServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.Random;
 import java.util.UUID;
 
 @Service
@@ -24,7 +23,7 @@ public class MatchServiceImpl implements MatchService {
     private final MatchPlayerRepository matchPlayerRepository;
 
     private MatchPlayer createMatchPlayer(Long matchId, UUID playerId) {
-        if (matchPlayerRepository.findByMatchIdAndUserId(matchId, playerId).isPresent()) {
+        if (matchPlayerRepository.findByMatchIdAndId(matchId, playerId).isPresent()) {
             throw new GameRuleViolationException("Player is already in the match");
         }
         MatchPlayer matchPlayer = new MatchPlayer();
@@ -77,10 +76,6 @@ public class MatchServiceImpl implements MatchService {
 
         match.getPlayers().add(matchPlayer);
 
-        Random random = new Random();
-
-        MatchPlayer firstPlayer = match.getPlayers().get(random.nextInt(match.getPlayers().size()));
-        match.setCurrentPlayerTurnId(firstPlayer.getUserId());
         match.setStatus(MatchStatus.PLANNING);
         matchRepository.save(match);
 
@@ -88,11 +83,11 @@ public class MatchServiceImpl implements MatchService {
 
     }
 
-//    @Override
-//    public Match getMatchById(Long matchId) {
-//        return matchRepository.findById(matchId)
-//                .orElseThrow(() -> new IllegalArgumentException("Match not found"));
-//    }
+    @Override
+    public Match getMatchById(Long matchId) {
+        return matchRepository.findById(matchId)
+                .orElseThrow(() -> new IllegalArgumentException("Match not found"));
+    }
 
     @Override
     public Match getMatchByInviteToken(String inviteToken) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,6 +8,3 @@ jwt.secret=AvaBwBD0xSg1ZlAop3WyS3XxdvjRJ9ezTAKjYQ0dak2
 refresh.token.expiration=604800000
 access.token.expiration=900000
 # --- Basic auth (dev convenience; consider overriding/turning off in prod later) ---
-spring.security.user.name=admin
-spring.security.user.password=admin123
-spring.security.user.roles=ADMIN


### PR DESCRIPTION
This pull request introduces several changes to the entity and service layers to improve type safety and match management logic. The most significant updates include switching primary keys to UUIDs for the `MatchPlayer` entity, updating repository methods to reflect this change, and adding new functionality to the match service. Additionally, an enum value was added for game state tracking and some unused code was cleaned up.

**Entity and Repository Updates:**
* Changed the primary key type of `MatchPlayer` from `Long` to `UUID` and updated the `userId` field to use `@Column` instead of `@JoinColumn` in `MatchPlayer.java`.
* Updated repository methods in `MatchPlayerRepository` to use `MatchPlayerId` (UUID) instead of `userId`, and added a method to find by `reconnectToken`.

**Service Layer Improvements:**
* Modified the logic in `MatchServiceImpl` to use the new repository method (`findByMatchIdAndId`) for checking player existence, and removed random selection for the first player turn. [[1]](diffhunk://#diff-84552367d77e24790ac7ea5855dc8e315856c8fe03f153ea34c45e5e249038e2L27-R26) [[2]](diffhunk://#diff-84552367d77e24790ac7ea5855dc8e315856c8fe03f153ea34c45e5e249038e2L80-R90)
* Exposed the `getMatchById` method in the `MatchService` interface and implemented it in `MatchServiceImpl`. [[1]](diffhunk://#diff-3526fc4c0b5ea49f54f5ac0ca98f2a47825d611547f0120b0292b10bc8c9bea9L19-R19) [[2]](diffhunk://#diff-84552367d77e24790ac7ea5855dc8e315856c8fe03f153ea34c45e5e249038e2L80-R90)

**Game Logic Enhancement:**
* Added a new `FINISHED` value to the `MoveResult` enum to represent the end of a match.

**General Cleanup:**
* Removed unused imports and configuration properties related to basic auth credentials. [[1]](diffhunk://#diff-84552367d77e24790ac7ea5855dc8e315856c8fe03f153ea34c45e5e249038e2L15) [[2]](diffhunk://#diff-54eeffbae371fcd1398d4ca5e89a1b8118208b7bb2f8ddf55c1aa2f7d98ab136L11-L13)