### PR TITLE
feat(websocket): implement WebSocket messaging DTOs and service events

### DIFF
--- a/src/main/java/com/chnu/seabattle/config/WebSocketConfig.java
+++ b/src/main/java/com/chnu/seabattle/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package com.chnu.seabattle.config;
 
+import com.chnu.seabattle.security.StompMatchPlayerAuthInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +11,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompMatchPlayerAuthInterceptor stompMatchPlayerAuthInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -17,9 +23,15 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.setApplicationDestinationPrefixes("/app");
     }
 
-
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompMatchPlayerAuthInterceptor);
     }
 }

--- a/src/main/java/com/chnu/seabattle/dto/MatchStatusMessage.java
+++ b/src/main/java/com/chnu/seabattle/dto/MatchStatusMessage.java
@@ -1,0 +1,17 @@
+package com.chnu.seabattle.dto;
+
+import com.chnu.seabattle.entity.MatchStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+public class MatchStatusMessage {
+    Long matchId;
+    MatchStatus matchStatus;
+    Instant at;
+    UUID currentTurnPlayerId;
+}

--- a/src/main/java/com/chnu/seabattle/dto/MoveMessage.java
+++ b/src/main/java/com/chnu/seabattle/dto/MoveMessage.java
@@ -1,0 +1,21 @@
+package com.chnu.seabattle.dto;
+
+import com.chnu.seabattle.entity.MoveResult;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+public class MoveMessage {
+
+    Long matchId;
+    UUID recipientMatchPlayerId;
+    int x;
+    int y;
+    MoveResult result;
+    Instant at;
+    UUID nextTurnPlayerId;
+}

--- a/src/main/java/com/chnu/seabattle/dto/PresenceMessage.java
+++ b/src/main/java/com/chnu/seabattle/dto/PresenceMessage.java
@@ -1,0 +1,16 @@
+package com.chnu.seabattle.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+public class PresenceMessage {
+    Long matchId;
+    UUID matchPlayerId;
+    PresenseEventType presenseEventType;
+    Instant at;
+}

--- a/src/main/java/com/chnu/seabattle/dto/PresenseEventType.java
+++ b/src/main/java/com/chnu/seabattle/dto/PresenseEventType.java
@@ -1,0 +1,8 @@
+package com.chnu.seabattle.dto;
+
+public enum PresenseEventType {
+    OPPONENT_CONNECTED,
+    OPPONENT_READY,
+    DISCONNECTED,
+    RECONNECTED
+}

--- a/src/main/java/com/chnu/seabattle/security/StompMatchPlayerAuthInterceptor.java
+++ b/src/main/java/com/chnu/seabattle/security/StompMatchPlayerAuthInterceptor.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.stereotype.Component;
 
 import java.security.Principal;
+import java.util.UUID;
 
 
 @Component
@@ -21,7 +22,7 @@ import java.security.Principal;
 public class StompMatchPlayerAuthInterceptor implements ChannelInterceptor {
 
     private static final String H_MATCH_ID = "X-Match-Id";
-    private static final String H_RECONNECT_TOKEN = "X-Reconnect-Token";
+    private static final String H_MATCH_PLAYER_ID = "X-Match-Player-Id";
 
     private final MatchPlayerRepository matchPlayerRepository;
 
@@ -36,14 +37,14 @@ public class StompMatchPlayerAuthInterceptor implements ChannelInterceptor {
 
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             Long matchId = parseLongHeader(accessor, H_MATCH_ID);
-            String reconnectToken = firstNativeHeader(accessor, H_RECONNECT_TOKEN);
+            UUID matchPlayerId = UUID.fromString(firstNativeHeader(accessor, H_MATCH_PLAYER_ID));
 
-            if (matchId == null || reconnectToken == null || reconnectToken.isBlank()) {
-                throw new IllegalArgumentException("Missing X-Match-Id / X-Reconnect-Token");
+            if (matchId == null || matchPlayerId == null) {
+                throw new IllegalArgumentException("Missing X-Match-Id / X-Match-Player-Id");
             }
             MatchPlayer mp = matchPlayerRepository
-                    .findByMatchIdAndReconnectToken(matchId, reconnectToken)
-                    .orElseThrow(() -> new IllegalArgumentException("Invalid X-Match-Id / X-Reconnect-Token"));
+                    .findByMatchIdAndId(matchId, matchPlayerId)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid X-Match-Id / X-Match-Player-Id"));
 
             Principal principal = new UsernamePasswordAuthenticationToken(
                     mp.getId().toString(), null, null

--- a/src/main/java/com/chnu/seabattle/security/StompMatchPlayerAuthInterceptor.java
+++ b/src/main/java/com/chnu/seabattle/security/StompMatchPlayerAuthInterceptor.java
@@ -1,0 +1,73 @@
+package com.chnu.seabattle.security;
+
+import com.chnu.seabattle.entity.MatchPlayer;
+import com.chnu.seabattle.repository.MatchPlayerRepository;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+
+@Component
+@RequiredArgsConstructor
+public class StompMatchPlayerAuthInterceptor implements ChannelInterceptor {
+
+    private static final String H_MATCH_ID = "X-Match-Id";
+    private static final String H_RECONNECT_TOKEN = "X-Reconnect-Token";
+
+    private final MatchPlayerRepository matchPlayerRepository;
+
+    @Override
+    public Message<?> preSend(@NonNull Message<?> message, @NonNull MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) {
+            return message;
+        }
+
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            Long matchId = parseLongHeader(accessor, H_MATCH_ID);
+            String reconnectToken = firstNativeHeader(accessor, H_RECONNECT_TOKEN);
+
+            if (matchId == null || reconnectToken == null || reconnectToken.isBlank()) {
+                throw new IllegalArgumentException("Missing X-Match-Id / X-Reconnect-Token");
+            }
+            MatchPlayer mp = matchPlayerRepository
+                    .findByMatchIdAndReconnectToken(matchId, reconnectToken)
+                    .orElseThrow(() -> new IllegalArgumentException("Invalid X-Match-Id / X-Reconnect-Token"));
+
+            Principal principal = new UsernamePasswordAuthenticationToken(
+                    mp.getId().toString(), null, null
+            );
+
+            accessor.setUser(principal);
+
+            accessor.getSessionAttributes().put("matchId", matchId);
+            accessor.getSessionAttributes().put("matchPlayerId", mp.getId());
+        }
+        return message;
+    }
+
+    private static String firstNativeHeader(StompHeaderAccessor accessor, String name) {
+        return accessor.getFirstNativeHeader(name);
+    }
+
+    private static Long parseLongHeader(StompHeaderAccessor accessor, String name) {
+        String v = accessor.getFirstNativeHeader(name);
+        if (v == null) return null;
+        try {
+            return Long.parseLong(v);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(String.format("Invalid %s", name));
+        }
+    }
+}

--- a/src/main/java/com/chnu/seabattle/service/WebSocketService.java
+++ b/src/main/java/com/chnu/seabattle/service/WebSocketService.java
@@ -1,0 +1,28 @@
+package com.chnu.seabattle.service;
+
+import com.chnu.seabattle.entity.MatchStatus;
+import com.chnu.seabattle.entity.MoveResult;
+
+import java.util.UUID;
+
+public interface WebSocketService {
+
+    void handleOpponentConnected(Long matchId, UUID matchPlayerId);
+
+    void handleDisconnect(Long matchId, UUID matchPlayerId);
+
+    void sendPlayerReadyMessage(Long matchId, UUID matchPlayerId);
+
+    void handleReconnect(Long matchId, UUID matchPlayerId);
+
+    void updateMatchStatus(Long matchId, MatchStatus matchStatus, UUID currentTurnPlayerId);
+
+    void sendOpponentMoveMessage(
+            Long matchId,
+            UUID recipientMatchPlayerId,
+            int x,
+            int y,
+            MoveResult moveResult,
+            UUID nextTurnPlayerId
+    );
+}

--- a/src/main/java/com/chnu/seabattle/service/serviceImpl/WebSocketServiceImpl.java
+++ b/src/main/java/com/chnu/seabattle/service/serviceImpl/WebSocketServiceImpl.java
@@ -1,0 +1,126 @@
+package com.chnu.seabattle.service.serviceImpl;
+
+import com.chnu.seabattle.dto.MatchStatusMessage;
+import com.chnu.seabattle.dto.MoveMessage;
+import com.chnu.seabattle.dto.PresenceMessage;
+import com.chnu.seabattle.dto.PresenseEventType;
+import com.chnu.seabattle.entity.MatchStatus;
+import com.chnu.seabattle.entity.MoveResult;
+import com.chnu.seabattle.service.WebSocketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class WebSocketServiceImpl implements WebSocketService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private String presenceTopic(Long matchId) {
+        return "/topic/match/" + matchId + "/presence";
+    }
+
+    private String statusTopic(Long matchId) {
+        return "/topic/match/" + matchId + "/status";
+    }
+
+    private String privateQueue(Long matchId) {
+        return "/queue/match/" + matchId;
+    }
+
+    @Override
+    public void handleOpponentConnected(Long matchId, UUID matchPlayerId) {
+        messagingTemplate.convertAndSend(
+                presenceTopic(matchId),
+                PresenceMessage.builder()
+                        .matchId(matchId)
+                        .matchPlayerId(matchPlayerId)
+                        .presenseEventType(PresenseEventType.OPPONENT_CONNECTED)
+                        .at(Instant.now())
+                        .build()
+        );
+    }
+
+    @Override
+    public void handleDisconnect(Long matchId, UUID matchPlayerId) {
+        messagingTemplate.convertAndSend(
+                presenceTopic(matchId),
+                PresenceMessage.builder()
+                        .matchId(matchId)
+                        .matchPlayerId(matchPlayerId)
+                        .presenseEventType(PresenseEventType.DISCONNECTED)
+                        .at(Instant.now())
+                        .build()
+        );
+    }
+
+    @Override
+    public void sendPlayerReadyMessage(Long matchId, UUID matchPlayerId) {
+        messagingTemplate.convertAndSend(
+                presenceTopic(matchId),
+                PresenceMessage.builder()
+                        .matchId(matchId)
+                        .matchPlayerId(matchPlayerId)
+                        .presenseEventType(PresenseEventType.OPPONENT_READY)
+                        .at(Instant.now())
+                        .build()
+        );
+    }
+
+    @Override
+    public void handleReconnect(Long matchId, UUID matchPlayerId) {
+        messagingTemplate.convertAndSend(
+                presenceTopic(matchId),
+                PresenceMessage.builder()
+                        .matchId(matchId)
+                        .matchPlayerId(matchPlayerId)
+                        .presenseEventType(PresenseEventType.RECONNECTED)
+                        .at(Instant.now())
+                        .build()
+        );
+    }
+
+    @Override
+    public void updateMatchStatus(Long matchId, MatchStatus matchStatus, UUID currentTurnPlayerId) {
+        messagingTemplate.convertAndSend(
+                statusTopic(matchId),
+                MatchStatusMessage.builder()
+                        .matchId(matchId)
+                        .matchStatus(matchStatus)
+                        .at(Instant.now())
+                        .currentTurnPlayerId(currentTurnPlayerId)
+                        .build()
+        );
+    }
+
+    @Override
+    public void sendOpponentMoveMessage(
+            Long matchId,
+            UUID recipientMatchPlayerId,
+            int x,
+            int y,
+            MoveResult moveResult,
+            UUID nextTurnPlayerId
+    ) {
+        MoveMessage payload = MoveMessage.builder()
+                .matchId(matchId)
+                .recipientMatchPlayerId(recipientMatchPlayerId)
+                .x(x)
+                .y(y)
+                .result(moveResult)
+                .at(Instant.now())
+                .nextTurnPlayerId(nextTurnPlayerId)
+                .build();
+
+        messagingTemplate.convertAndSendToUser(
+                recipientMatchPlayerId.toString(),
+                privateQueue(matchId),
+                payload
+        );
+
+    }
+}


### PR DESCRIPTION
This pull request introduces a robust WebSocket messaging infrastructure for the Sea Battle application, focusing on authenticated STOMP connections and real-time communication of match and player events. The changes include a custom STOMP authentication interceptor, new DTOs for WebSocket messages, and a service layer for handling and broadcasting match-related events.

**WebSocket Security and Configuration**

* Added a `StompMatchPlayerAuthInterceptor` to authenticate incoming STOMP connections using custom headers (`X-Match-Id` and `X-Match-Player-Id`), ensuring only valid match players can connect. (`src/main/java/com/chnu/seabattle/security/StompMatchPlayerAuthInterceptor.java` [[1]](diffhunk://#diff-242b956690e0e70ef14c621442cab0938fdb794795870c053469d5a3c9e316c8R3-R35) [[2]](diffhunk://#diff-78801c5d64ac218b133cf1ad5718072be07d76885736266dcf66c3d159736cebR1-R74)
* Updated `WebSocketConfig` to register the new interceptor for inbound channels and refactored the configuration to use constructor injection. (`src/main/java/com/chnu/seabattle/config/WebSocketConfig.java` [src/main/java/com/chnu/seabattle/config/WebSocketConfig.javaR3-R35](diffhunk://#diff-242b956690e0e70ef14c621442cab0938fdb794795870c053469d5a3c9e316c8R3-R35))

**WebSocket Messaging DTOs**

* Introduced DTOs for WebSocket payloads:
  - [`PresenceMessage`](diffhunk://#diff-0d82d0d652d8d316cd6166b23ad0239e77a62a387885037eb65a9c63128870b9R1-R16): Notifies about player presence events (connected, ready, disconnected, reconnected). (`src/main/java/com/chnu/seabattle/dto/PresenceMessage.java` [src/main/java/com/chnu/seabattle/dto/PresenceMessage.javaR1-R16](diffhunk://#diff-0d82d0d652d8d316cd6166b23ad0239e77a62a387885037eb65a9c63128870b9R1-R16))
  - [`PresenseEventType`](diffhunk://#diff-206c8c25b6411a9324b5cdddf3d12346ac17ed9a6abe9b5c4a29386ada64e01bR1-R8): Enum for presence event types. (`src/main/java/com/chnu/seabattle/dto/PresenseEventType.java` [src/main/java/com/chnu/seabattle/dto/PresenseEventType.javaR1-R8](diffhunk://#diff-206c8c25b6411a9324b5cdddf3d12346ac17ed9a6abe9b5c4a29386ada64e01bR1-R8))
  - [`MatchStatusMessage`](diffhunk://#diff-6f6dbcd2144dab19e9f578f94c6e8afa802956b55b931a411e5a4e998a55344eR1-R17): Communicates match status updates. (`src/main/java/com/chnu/seabattle/dto/MatchStatusMessage.java` [src/main/java/com/chnu/seabattle/dto/MatchStatusMessage.javaR1-R17](diffhunk://#diff-6f6dbcd2144dab19e9f578f94c6e8afa802956b55b931a411e5a4e998a55344eR1-R17))
  - [`MoveMessage`](diffhunk://#diff-8a718e3dfe4248c69b7e8a9d9b5b9026bda858a9cde0b43b8e07972b2478ee3fR1-R21): Communicates move results to players. (`src/main/java/com/chnu/seabattle/dto/MoveMessage.java` [src/main/java/com/chnu/seabattle/dto/MoveMessage.javaR1-R21](diffhunk://#diff-8a718e3dfe4248c69b7e8a9d9b5b9026bda858a9cde0b43b8e07972b2478ee3fR1-R21))

**WebSocket Service Layer**

* Added `WebSocketService` interface and its implementation `WebSocketServiceImpl` to encapsulate logic for broadcasting presence, status, and move messages to appropriate topics and user queues. (`src/main/java/com/chnu/seabattle/service/WebSocketService.java` [[1]](diffhunk://#diff-4fc3f3d5577723ea910d20e90fb05f093152d3a81d27e887795751819517d19cR1-R28) `src/main/java/com/chnu/seabattle/service/serviceImpl/WebSocketServiceImpl.java` [[2]](diffhunk://#diff-b6ae4d7c9f55530c481cdf1158746a42daa6ddf4129a33c50fe69d5c5e1f263bR1-R126)